### PR TITLE
Update xmpp-rs dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["api-bindings", "science"]
 
 [dependencies]
 thiserror = "1.0"
-tokio-xmpp = "3.1"
-xmpp-parsers = "0.18"
+tokio-xmpp = "3.2"
+xmpp-parsers = "0.19"
 jid = "0.9"
 futures = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4"
 log = "0.4"
-tokio = { version = "1.16", features = ["sync", "time", "rt"] }
+tokio = { version = "1.17", features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
 env_logger = "0.9"
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1.17", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ futures = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4"
 log = "0.4"
-tokio = { version = "1.17", features = ["sync", "time", "rt"] }
+tokio = { version = "1", features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
 env_logger = "0.9"
-tokio = { version = "1.17", features = ["full"] }
+tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Some components of the `xmpp-rs` workspace had breakages in published crates, which would then break the build of `nwws-oi`. These breakages have since been fixed, as far as I can tell.

This PR updates the `xmpp-parsers` and `tokio-xmpp` dependencies, and relaxes the version constraint for `tokio`.